### PR TITLE
Fix invalid summon of Factory

### DIFF
--- a/core/src/test/scala/one/estrondo/farango/DefaultTestTypeClasses.scala
+++ b/core/src/test/scala/one/estrondo/farango/DefaultTestTypeClasses.scala
@@ -39,7 +39,7 @@ given [I[_] <: Iterable[_], F[_]: Extractor](using Factory[Any, I[Any]]): Effect
 
   override def fromJavaStream[A](a: F[stream.Stream[A]]): I[A] =
     val list    = summon[Extractor[F]].get(a).collect(Collectors.toList)
-    val builder = summon[Factory[_, I[_]]].newBuilder
+    val builder = summon[Factory[Any, I[Any]]].newBuilder
     for item <- list.asScala do builder.addOne(item.asInstanceOf[A])
 
     builder.result().asInstanceOf[I[A]]


### PR DESCRIPTION
Hey, I've stumbled onto your project in Scala 3 Open Community Build. Scala 3.3.1-RC4 ships with a typer improvment which now detects incorrect summon usage in your code. 
The `summon[Factory[_, I[_]]]` is an invalid usage of implicit resolution, instead you should use `summon[Factory[Any, I[Any]]]` 

Reproduction and discussion: https://github.com/lampepfl/dotty/issues/18350 
OpenCB [build logs](https://github.com/VirtusLab/community-build3/actions/runs/5772754805/job/15648069603)
